### PR TITLE
Allow setting IT content flag, and make it default

### DIFF
--- a/src/hdmi.sv
+++ b/src/hdmi.sv
@@ -8,6 +8,17 @@ module hdmi
     // Pixel repetition, interlaced scans and other special output modes are not implemented (yet).
     parameter int VIDEO_ID_CODE = 1,
 
+    // The IT content bit indicates that image samples are generated in an ad-hoc
+    // manner (e.g. directly from values in a framebuffer, as by a PC video
+    // card) and therefore aren't suitable for filtering or analog
+    // reconstruction.  This is probably what you want if you treat pixels
+    // as "squares".  If you generate a properly bandlimited signal or obtain
+    // one from elsewhere (e.g. a camera), this can be turned off.
+    //
+    // This flag also tends to cause receivers to treat RGB values as full
+    // range (0-255).
+    parameter bit IT_CONTENT = 1'b1,
+
     // Defaults to minimum bit lengths required to represent positions.
     // Modify these parameters if you have alternate desired bit lengths.
     parameter int BIT_WIDTH = VIDEO_ID_CODE < 4 ? 10 : VIDEO_ID_CODE == 4 ? 11 : 12,
@@ -269,6 +280,7 @@ generate
         packet_picker #(
             .VIDEO_ID_CODE(VIDEO_ID_CODE),
             .VIDEO_RATE(VIDEO_RATE),
+            .IT_CONTENT(IT_CONTENT),
             .AUDIO_RATE(AUDIO_RATE),
             .AUDIO_BIT_WIDTH(AUDIO_BIT_WIDTH),
             .VENDOR_NAME(VENDOR_NAME),

--- a/src/packet_picker.sv
+++ b/src/packet_picker.sv
@@ -5,6 +5,7 @@ module packet_picker
 #(
     parameter int VIDEO_ID_CODE = 4,
     parameter real VIDEO_RATE = 0,
+    parameter bit IT_CONTENT = 1'b0,
     parameter int AUDIO_BIT_WIDTH = 0,
     parameter int AUDIO_RATE = 0,
     parameter bit [8*8-1:0] VENDOR_NAME = 0,
@@ -130,7 +131,10 @@ end
 audio_sample_packet #(.SAMPLING_FREQUENCY(SAMPLING_FREQUENCY), .WORD_LENGTH({{WORD_LENGTH[0], WORD_LENGTH[1], WORD_LENGTH[2]}, WORD_LENGTH_LIMIT})) audio_sample_packet (.frame_counter(frame_counter), .valid_bit('{2'b00, 2'b00, 2'b00, 2'b00}), .user_data_bit('{2'b00, 2'b00, 2'b00, 2'b00}), .audio_sample_word(audio_sample_word_packet), .audio_sample_word_present(audio_sample_word_present_packet), .header(headers[2]), .sub(subs[2]));
 
 
-auxiliary_video_information_info_frame #(.VIDEO_ID_CODE(7'(VIDEO_ID_CODE))) auxiliary_video_information_info_frame(.header(headers[130]), .sub(subs[130]));
+auxiliary_video_information_info_frame #(
+    .VIDEO_ID_CODE(7'(VIDEO_ID_CODE)),
+    .IT_CONTENT(IT_CONTENT)
+) auxiliary_video_information_info_frame(.header(headers[130]), .sub(subs[130]));
 
 
 source_product_description_info_frame #(.VENDOR_NAME(VENDOR_NAME), .PRODUCT_DESCRIPTION(PRODUCT_DESCRIPTION), .SOURCE_DEVICE_INFORMATION(SOURCE_DEVICE_INFORMATION)) source_product_description_info_frame(.header(headers[131]), .sub(subs[131]));


### PR DESCRIPTION
This is usually what you want for ad-hoc image generation.
Applications that explicitly generate bandlimited signals
can turn it off.