### PR TITLE
hdmi: allow setting start x/y with parameters

### DIFF
--- a/src/hdmi.sv
+++ b/src/hdmi.sv
@@ -35,7 +35,21 @@ module hdmi
     // If you care about this, change it below.
     parameter bit [8*8-1:0] VENDOR_NAME = {"Unknown", 8'd0}, // Must be 8 bytes null-padded 7-bit ASCII
     parameter bit [8*16-1:0] PRODUCT_DESCRIPTION = {"FPGA", 96'd0}, // Must be 16 bytes null-padded 7-bit ASCII
-    parameter bit [7:0] SOURCE_DEVICE_INFORMATION = 8'h00 // See README.md or CTA-861-G for the list of valid codes
+    parameter bit [7:0] SOURCE_DEVICE_INFORMATION = 8'h00, // See README.md or CTA-861-G for the list of valid codes
+
+    // Starting screen coordinate when module comes out of reset.
+    //
+    // Setting these to something other than (0, 0) is useful when positioning
+    // an external video signal within a larger overall frame (e.g.
+    // letterboxing an input video signal). This allows you to synchronize the
+    // negative edge of reset directly to the start of the external signal
+    // instead of to some number of clock cycles before.
+    //
+    // You probably don't need to change these parameters if you are
+    // generating a signal from scratch instead of processing an
+    // external signal.
+    parameter int START_X = 0,
+    parameter int START_Y = 0
 )
 (
     input logic clk_pixel_x5,
@@ -53,8 +67,8 @@ module hdmi
     // All outputs below this line stay inside the FPGA
     // They are used (by you) to pick the color each pixel should have
     // i.e. always_ff @(posedge pixel_clk) rgb <= {8'd0, 8'(cx), 8'(cy)};
-    output logic [BIT_WIDTH-1:0] cx = BIT_WIDTH'(0),
-    output logic [BIT_HEIGHT-1:0] cy = BIT_HEIGHT'(0),
+    output logic [BIT_WIDTH-1:0] cx = START_X,
+    output logic [BIT_HEIGHT-1:0] cy = START_Y,
 
     // The screen is at the upper left corner of the frame.
     // 0,0 = 0,0 in video
@@ -180,8 +194,8 @@ always_ff @(posedge clk_pixel)
 begin
     if (reset)
     begin
-        cx <= BIT_WIDTH'(0);
-        cy <= BIT_HEIGHT'(0);
+        cx <= BIT_WIDTH'(START_X);
+        cy <= BIT_HEIGHT'(START_Y);
     end
     else
     begin


### PR DESCRIPTION
gbaHD needs this synchronize the hdmi output with the start of a GBA
frame, with the GBA image centered within the HDMI frame instead of
starting at 0,0.

It's easier and uses fewer FPGA resources to start the hdmi block in the
middle of a frame than to count off the right number of cycles from GBA
vsync to achieve the same phase relationship.  Receivers need to be able
to synchronize from mid-stream anyway, so this doesn't cause any
problems.