### PR TITLE
Refactor video attributes

### DIFF
--- a/src/Manifest.py
+++ b/src/Manifest.py
@@ -1,5 +1,6 @@
 files = [
     "hdmi.sv",
+    "hdmi_attr.sv",
     "tmds_channel.sv",
     "packet_assembler.sv",
     "packet_picker.sv",

--- a/src/hdmi_attr.sv
+++ b/src/hdmi_attr.sv
@@ -1,0 +1,134 @@
+// Package for representing/manipulating HDMI stream attributes
+package hdmi_attr;
+
+// Basic video attributes
+typedef struct {
+    // Width/height of HDMI frame, including blanking periods
+    int frame_width;
+    int frame_height;
+    // Width/height of screen (active video)
+    int screen_width;
+    int screen_height;
+    // Start of hsync pulse in pixel clock cycles after start of horizontal
+    // blanking
+    int hsync_pulse_start;
+    // Size of hsync pulse in pixel clock cycles
+    int hsync_pulse_size;
+    // Start of vsync pulse in scanlines after start of vertical blanking. The
+    // pulse is always aligned with the start of hsync on the indicated
+    // scanline (as required by CEA-861-D), so the actual start is
+    // (frame_width * vsync_pulse_start + hsync_pulse_start) pixel clock
+    // cycles after the last active pixel.
+    int vsync_pulse_start;
+    // Size of vsync pulse in scanlines
+    int vsync_pulse_size;
+    // Sync pulses are negative-going if true
+    logic invert;
+    // Base pixel clock rate in Hz.  Can be modified when using 59.94/29.97
+    // vertical refresh rate.
+    real base_pixel_clock;
+} video_attr_t;
+
+// Get video attributes for supported CEA-861-D video ID code
+function video_attr_t video_attr_for_id(int code);
+    case (code)
+    1: return '{
+        frame_width: 800,
+        frame_height: 525,
+        screen_width: 640,
+        screen_height: 480,
+        hsync_pulse_start: 16,
+        hsync_pulse_size: 96,
+        vsync_pulse_start: 10,
+        vsync_pulse_size: 2,
+        invert: 1,
+        base_pixel_clock: 25.2E6
+    };
+    2, 3: return '{
+        frame_width: 858,
+        frame_height: 525,
+        screen_width: 720,
+        screen_height: 480,
+        hsync_pulse_start: 16,
+        hsync_pulse_size: 62,
+        vsync_pulse_start: 9,
+        vsync_pulse_size: 6,
+        invert: 1,
+        base_pixel_clock: 27.027E6
+    };
+    4: return '{
+        frame_width: 1650,
+        frame_height: 750,
+        screen_width: 1280,
+        screen_height: 720,
+        hsync_pulse_start: 110,
+        hsync_pulse_size: 40,
+        vsync_pulse_start: 5,
+        vsync_pulse_size: 5,
+        invert: 0,
+        base_pixel_clock: 74.25E6
+    };
+    16: return '{
+        frame_width: 2200,
+        frame_height: 1125,
+        screen_width: 1920,
+        screen_height: 1080,
+        hsync_pulse_start: 88,
+        hsync_pulse_size: 44,
+        vsync_pulse_start: 4,
+        vsync_pulse_size: 5,
+        invert: 0,
+        base_pixel_clock: 148.5E6
+    };
+    17, 18: return '{
+        frame_width: 864,
+        frame_height: 625,
+        screen_width: 720,
+        screen_height: 576,
+        hsync_pulse_start: 12,
+        hsync_pulse_size: 64,
+        vsync_pulse_start: 5,
+        vsync_pulse_size: 5,
+        invert: 1,
+        base_pixel_clock: 27E6
+    };
+    19: return '{
+        frame_width: 1980,
+        frame_height: 750,
+        screen_width: 1280,
+        screen_height: 720,
+        hsync_pulse_start: 440,
+        hsync_pulse_size: 40,
+        vsync_pulse_start: 5,
+        vsync_pulse_size: 5,
+        invert: 0,
+        base_pixel_clock: 74.25E6
+    };
+    34: return '{
+        frame_width: 2200,
+        frame_height: 1125,
+        screen_width: 1920,
+        screen_height: 1080,
+        hsync_pulse_start: 88,
+        hsync_pulse_size: 44,
+        vsync_pulse_start: 4,
+        vsync_pulse_size: 5,
+        invert: 0,
+        base_pixel_clock: 74.25E6
+    };
+    95, 105, 97, 107: return '{
+        frame_width: 4400,
+        frame_height: 2250,
+        screen_width: 3840,
+        screen_height: 2160,
+        hsync_pulse_start: 176,
+        hsync_pulse_size: 88,
+        vsync_pulse_start: 8,
+        vsync_pulse_size: 10,
+        invert: 0,
+        base_pixel_clock: 595E6
+    };
+    endcase
+endfunction
+
+endpackage

--- a/test/top_tb/top_tb.sv
+++ b/test/top_tb/top_tb.sv
@@ -108,15 +108,15 @@ logic [15:0] previous_sample [1:0];
 integer k;
 always @(posedge top.clk_pixel)
 begin
-  cx <= cx == top.frame_width - 1 ? 0 : cx + 1;
-  cy <= cx == top.frame_width-1'b1 ? cy == top.frame_height-1'b1 ? 0 : cy + 1'b1 : cy;
-  if (top.hdmi.true_hdmi_output.num_packets_alongside > 0 && (cx >= top.screen_width + 8 && cx < top.screen_width + 10) || (cx >= top.screen_width + 10 + top.hdmi.true_hdmi_output.num_packets_alongside * 32 && cx < top.screen_width + 10 + top.hdmi.true_hdmi_output.num_packets_alongside * 32 + 2))
+  cx <= cx == top.hdmi.FRAME_WIDTH - 1 ? 0 : cx + 1;
+  cy <= cx == top.hdmi.FRAME_WIDTH-1'b1 ? cy == top.hdmi.FRAME_HEIGHT-1'b1 ? 0 : cy + 1'b1 : cy;
+  if (top.hdmi.true_hdmi_output.num_packets_alongside > 0 && (cx >= top.hdmi.SCREEN_WIDTH + 8 && cx < top.hdmi.SCREEN_WIDTH + 10) || (cx >= top.hdmi.SCREEN_WIDTH + 10 + top.hdmi.true_hdmi_output.num_packets_alongside * 32 && cx < top.hdmi.SCREEN_WIDTH + 10 + top.hdmi.true_hdmi_output.num_packets_alongside * 32 + 2))
   begin
     assert(tmds_values[2] == 10'b0100110011) else $fatal("Channel 2 DI GB incorrect: %b", tmds_values[2]);
     assert(tmds_values[1] == 10'b0100110011) else $fatal("Channel 1 DI GB incorrect");
     assert(tmds_values[0] == 10'b1010001110 || tmds_values[0] == 10'b1001110001 || tmds_values[0] == 10'b0101100011 || tmds_values[0] == 10'b1011000011) else $fatal("Channel 0 DI GB incorrect");
   end
-  else if (top.hdmi.true_hdmi_output.num_packets_alongside > 0 && cx >= top.screen_width + 10 && cx < top.screen_width + 10 + top.hdmi.true_hdmi_output.num_packets_alongside * 32)
+  else if (top.hdmi.true_hdmi_output.num_packets_alongside > 0 && cx >= top.hdmi.SCREEN_WIDTH + 10 && cx < top.hdmi.SCREEN_WIDTH + 10 + top.hdmi.true_hdmi_output.num_packets_alongside * 32)
   begin
     data_counter <= data_counter + 1'd1;
     if (data_counter == 0)
@@ -126,7 +126,7 @@ begin
       sub[1][63:1] <= 63'dX;
       sub[0][63:1] <= 63'dX;
       header[31:1] <= 31'dX;
-      if (cx != top.screen_width + 10 || !first_packet) // Packet complete
+      if (cx != top.hdmi.SCREEN_WIDTH + 10 || !first_packet) // Packet complete
       begin
         first_packet <= 0;
         case(header[7:0])

--- a/top/top.sv
+++ b/top/top.sv
@@ -14,10 +14,7 @@ always @(posedge clk_audio)
   audio_sample_word <= '{audio_sample_word[1] + 16'd1, audio_sample_word[0] - 16'd1};
 
 logic [23:0] rgb = 24'd0;
-logic [9:0] cx, cy, screen_start_x, screen_start_y, frame_width, frame_height, screen_width, screen_height;
-// Border test (left = red, top = green, right = blue, bottom = blue, fill = black)
-always @(posedge clk_pixel)
-  rgb <= {cx == 0 ? ~8'd0 : 8'd0, cy == 0 ? ~8'd0 : 8'd0, cx == screen_width - 1'd1 || cy == screen_width - 1'd1 ? ~8'd0 : 8'd0};
+logic [9:0] cx, cy;
 
 // 640x480 @ 59.94Hz
 hdmi #(.VIDEO_ID_CODE(1), .VIDEO_REFRESH_RATE(59.94), .AUDIO_RATE(48000), .AUDIO_BIT_WIDTH(16)) hdmi(
@@ -30,11 +27,11 @@ hdmi #(.VIDEO_ID_CODE(1), .VIDEO_REFRESH_RATE(59.94), .AUDIO_RATE(48000), .AUDIO
   .tmds(tmds),
   .tmds_clock(tmds_clock),
   .cx(cx),
-  .cy(cy),
-  .frame_width(frame_width),
-  .frame_height(frame_height),
-  .screen_width(screen_width),
-  .screen_height(screen_height)
+  .cy(cy)
 );
+//
+// Border test (left = red, top = green, right = blue, bottom = blue, fill = black)
+always @(posedge clk_pixel)
+  rgb <= {cx == 0 ? ~8'd0 : 8'd0, cy == 0 ? ~8'd0 : 8'd0, cx == hdmi.SCREEN_WIDTH - 1'd1 || cy == hdmi.SCREEN_HEIGHT - 1'd1 ? ~8'd0 : 8'd0};
 
 endmodule


### PR DESCRIPTION
gbaHD no longer needs custom video timings, but this refactoring makes it easier if anyone ever does.

- Abstract video attributes and video ID code lookup into a package
- All video attributes are now static values rather than signals
  within the hdmi block.  The width/height output signals are removed
  since they are available by accessing hdmi localparams or through the
  hdmi_attr package.
- Allow using custom video attributes if desired