### PR TITLE
Added Gowin serializer.

### DIFF
--- a/src/serializer.sv
+++ b/src/serializer.sv
@@ -109,6 +109,57 @@ module serializer
                 end
             endgenerate
         `endif
+    `elsif GW_IDE
+        OSER10 gwSer0( 
+            .Q( tmds[ 0 ] ),
+            .D0( tmds_internal[ 0 ][ 0 ] ),
+            .D1( tmds_internal[ 0 ][ 1 ] ),
+            .D2( tmds_internal[ 0 ][ 2 ] ),
+            .D3( tmds_internal[ 0 ][ 3 ] ),
+            .D4( tmds_internal[ 0 ][ 4 ] ),
+            .D5( tmds_internal[ 0 ][ 5 ] ),
+            .D6( tmds_internal[ 0 ][ 6 ] ),
+            .D7( tmds_internal[ 0 ][ 7 ] ),
+            .D8( tmds_internal[ 0 ][ 8 ] ),
+            .D9( tmds_internal[ 0 ][ 9 ] ),
+            .PCLK( clk_pixel ),
+            .FCLK( clk_pixel_x5 ),
+            .RESET( reset ) );
+
+        OSER10 gwSer1( 
+          .Q( tmds[ 1 ] ),
+          .D0( tmds_internal[ 1 ][ 0 ] ),
+          .D1( tmds_internal[ 1 ][ 1 ] ),
+          .D2( tmds_internal[ 1 ][ 2 ] ),
+          .D3( tmds_internal[ 1 ][ 3 ] ),
+          .D4( tmds_internal[ 1 ][ 4 ] ),
+          .D5( tmds_internal[ 1 ][ 5 ] ),
+          .D6( tmds_internal[ 1 ][ 6 ] ),
+          .D7( tmds_internal[ 1 ][ 7 ] ),
+          .D8( tmds_internal[ 1 ][ 8 ] ),
+          .D9( tmds_internal[ 1 ][ 9 ] ),
+          .PCLK( clk_pixel ),
+          .FCLK( clk_pixel_x5 ),
+          .RESET( reset ) );
+
+        OSER10 gwSer2( 
+          .Q( tmds[ 2 ] ),
+          .D0( tmds_internal[ 2 ][ 0 ] ),
+          .D1( tmds_internal[ 2 ][ 1 ] ),
+          .D2( tmds_internal[ 2 ][ 2 ] ),
+          .D3( tmds_internal[ 2 ][ 3 ] ),
+          .D4( tmds_internal[ 2 ][ 4 ] ),
+          .D5( tmds_internal[ 2 ][ 5 ] ),
+          .D6( tmds_internal[ 2 ][ 6 ] ),
+          .D7( tmds_internal[ 2 ][ 7 ] ),
+          .D8( tmds_internal[ 2 ][ 8 ] ),
+          .D9( tmds_internal[ 2 ][ 9 ] ),
+          .PCLK( clk_pixel ),
+          .FCLK( clk_pixel_x5 ),
+          .RESET( reset ) );
+          
+        assign tmds_clock = clk_pixel;
+  
     `else
         logic [9:0] tmds_reversed [NUM_CHANNELS-1:0];
         genvar i, j;


### PR DESCRIPTION
Added serializer components for current Gowin FPGAs. As far as I can see, there is no variable set during synthesis using the Gowin synthesis tool, hence I added an "arbitrary" called "GW_IDE" which then has to be set prior in one of the source files.